### PR TITLE
Update ramsey/uuid version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "queue-interop/queue-interop": "^0.8",
         "enqueue/null": "^0.10",
         "enqueue/dsn": "^0.10",
-        "ramsey/uuid": "^2|^3.5",
+        "ramsey/uuid": "^2|^3.5|^4.0",
         "psr/log": "^1",
         "psr/container": "^1"
     },


### PR DESCRIPTION
According to [documentation](https://uuid.ramsey.dev/en/latest/upgrading/3-to-4.html):

> If you maintain a public project that uses ramsey/uuid version 3 and you find that your code does not require any changes to upgrade to version 4