### PR TITLE
Correct PHPDocs of doSendToRouter

### DIFF
--- a/Client/Driver/AmqpDriver.php
+++ b/Client/Driver/AmqpDriver.php
@@ -120,9 +120,9 @@ class AmqpDriver extends GenericDriver
     }
 
     /**
-     * @param AmqpProducer $producer
-     * @param AmqpTopic    $topic
-     * @param AmqpMessage  $transportMessage
+     * @param InteropProducer $producer
+     * @param Destination    $topic
+     * @param InteropMessage  $transportMessage
      */
     protected function doSendToRouter(InteropProducer $producer, Destination $topic, InteropMessage $transportMessage): void
     {

--- a/Client/Driver/AmqpDriver.php
+++ b/Client/Driver/AmqpDriver.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace  Enqueue\Client\Driver;
 
-use Enqueue\AmqpExt\AmqpProducer;
 use Enqueue\Client\Message;
 use Interop\Amqp\AmqpContext;
 use Interop\Amqp\AmqpMessage;
+use Interop\Amqp\AmqpProducer;
 use Interop\Amqp\AmqpQueue;
 use Interop\Amqp\AmqpTopic;
 use Interop\Amqp\Impl\AmqpBind;


### PR DESCRIPTION
The PHPDocs of doSendToRouter where not the same as the types of the method's arguments