### PR TITLE
Config fix

### DIFF
--- a/Symfony/Client/DependencyInjection/ClientFactory.php
+++ b/Symfony/Client/DependencyInjection/ClientFactory.php
@@ -79,7 +79,7 @@ final class ClientFactory
                 ->info('The array contains driver specific options')
                 ->ignoreExtraKeys(false)
             ->end()
-            ->end()->end()
+            ->end()
         ;
 
         return $builder;


### PR DESCRIPTION
SF 7.1

```
TypeError: Symfony\Component\Config\Definition\Builder\NodeDefinition::end(): Return value must be of type Symfony\Component\Config\Definition\Builder\NodeParentInterface, null returned
/srv/www/vendor/symfony/config/Definition/Builder/NodeDefinition.php:98
/srv/www/vendor/enqueue/enqueue/Symfony/Client/DependencyInjection/ClientFactory.php:82
/srv/www/vendor/enqueue/enqueue-bundle/DependencyInjection/Configuration.php:42
/srv/www/vendor/symfony/config/Definition/Processor.php:46
/srv/www/vendor/symfony/dependency-injection/Extension/Extension.php:109
/srv/www/vendor/enqueue/enqueue-bundle/DependencyInjection/EnqueueExtension.php:34
/srv/www/vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php:81
/srv/www/vendor/symfony/http-kernel/DependencyInjection/MergeExtensionConfigurationPass.php:40
/srv/www/vendor/symfony/dependency-injection/Compiler/Compiler.php:73
/srv/www/vendor/symfony/dependency-injection/ContainerBuilder.php:752
/srv/www/vendor/symfony/http-kernel/Kernel.php:495
/srv/www/vendor/symfony/http-kernel/Kernel.php:740
/srv/www/vendor/symfony/http-kernel/Kernel.php:120
/srv/www/vendor/symfony/framework-bundle/Test/KernelTestCase.php:67
```