### PR TITLE
Fix issue with last version 0.10.24 - composer update with symfony

### DIFF
--- a/Symfony/Client/ConsumeCommand.php
+++ b/Symfony/Client/ConsumeCommand.php
@@ -58,7 +58,7 @@ class ConsumeCommand extends Command
         string $defaultClient,
         string $queueConsumerIdPattern = 'enqueue.client.%s.queue_consumer',
         string $driverIdPattern = 'enqueue.client.%s.driver',
-        string $processorIdPatter = 'enqueue.client.%s.delegate_processor',
+        string $processorIdPatter = 'enqueue.client.%s.delegate_processor'
     ) {
         $this->container = $container;
         $this->defaultClient = $defaultClient;

--- a/Symfony/Consumption/ConfigurableConsumeCommand.php
+++ b/Symfony/Consumption/ConfigurableConsumeCommand.php
@@ -46,7 +46,7 @@ class ConfigurableConsumeCommand extends Command
         ContainerInterface $container,
         string $defaultTransport,
         string $queueConsumerIdPattern = 'enqueue.transport.%s.queue_consumer',
-        string $processorRegistryIdPattern = 'enqueue.transport.%s.processor_registry',
+        string $processorRegistryIdPattern = 'enqueue.transport.%s.processor_registry'
     ) {
         $this->container = $container;
         $this->defaultTransport = $defaultTransport;


### PR DESCRIPTION
Some comma was wrongly added in 2 files in the Symfony folder. This PR remove them (check the 2 commits). This has been successfully tested with Composer and Symfony

